### PR TITLE
Rename --exclude_schema to --exclude-schema for CLI consistency

### DIFF
--- a/packages/migra/migra/command.py
+++ b/packages/migra/migra/command.py
@@ -38,7 +38,7 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         help="Restrict output to statements for a particular schema",
     )
     parser.add_argument(
-        "--exclude_schema",
+        "--exclude-schema",
         dest="exclude_schema",
         default=None,
         help="Restrict output to statements for all schemas except the specified schema",

--- a/packages/migra/tests/test_cli.py
+++ b/packages/migra/tests/test_cli.py
@@ -1,0 +1,7 @@
+from migra.command import parse_args
+
+
+def test_exclude_schema_flag():
+    """Verify --exclude-schema flag works (kebab-case)."""
+    args = parse_args(["--exclude-schema", "myschema", "--unsafe", "EMPTY", "EMPTY"])
+    assert args.exclude_schema == "myschema"

--- a/packages/migra/tests/test_migra.py
+++ b/packages/migra/tests/test_migra.py
@@ -229,9 +229,3 @@ def do_fixture_test(
         args = parse_args(flags + ["EMPTY", "EMPTY"])
         out, err = outs()
         assert run(args, out=out, err=err) == 0
-
-
-def test_exclude_schema_flag():
-    """Verify --exclude-schema flag works (kebab-case)."""
-    args = parse_args(["--exclude-schema", "myschema", "--unsafe", "EMPTY", "EMPTY"])
-    assert args.exclude_schema == "myschema"

--- a/packages/migra/tests/test_migra.py
+++ b/packages/migra/tests/test_migra.py
@@ -123,7 +123,7 @@ def do_fixture_test(
     if schema:
         flags += ["--schema", schema]
     if exclude_schema:
-        flags += ["--exclude_schema", exclude_schema]
+        flags += ["--exclude-schema", exclude_schema]
     if create_extensions_only:
         flags += ["--create-extensions-only"]
     if ignore_extension_versions:
@@ -229,3 +229,9 @@ def do_fixture_test(
         args = parse_args(flags + ["EMPTY", "EMPTY"])
         out, err = outs()
         assert run(args, out=out, err=err) == 0
+
+
+def test_exclude_schema_flag():
+    """Verify --exclude-schema flag works (kebab-case)."""
+    args = parse_args(["--exclude-schema", "myschema", "--unsafe", "EMPTY", "EMPTY"])
+    assert args.exclude_schema == "myschema"


### PR DESCRIPTION
## Summary
- Rename the `--exclude_schema` CLI flag to `--exclude-schema` to match the kebab-case convention used by all other flags (`--create-extensions-only`, `--ignore-extension-versions`, `--with-privileges`, `--force-utf8`)
- The `dest="exclude_schema"` is preserved so no internal code changes are needed (argparse auto-converts hyphens to underscores)

Closes #9

## Test plan
- [ ] Verify `migra --help` shows `--exclude-schema` instead of `--exclude_schema`
- [ ] Verify `--exclude-schema` works correctly when passed as a CLI argument
- [ ] Verify no other references to the old flag name exist in the codebase

Generated with [Claude Code](https://claude.com/claude-code)