### PR TITLE
Fix diffing of functions with RETURNS TABLE

### DIFF
--- a/packages/migra/migra/schemainspect/pg/obj.py
+++ b/packages/migra/migra/schemainspect/pg/obj.py
@@ -288,6 +288,15 @@ class InspectedFunction(InspectedSelectable):
             and self.kind == other.kind
         )
 
+    def can_replace(self, other):
+        if self.signature != other.signature:
+            return False
+        if self.relationtype != other.relationtype:
+            return False
+        if self.result_string != other.result_string:
+            return False
+        return self.has_compatible_columns(other)
+
 
 class InspectedTrigger(Inspected):
     def __init__(

--- a/packages/migra/tests/test_migra.py
+++ b/packages/migra/tests/test_migra.py
@@ -229,3 +229,35 @@ def do_fixture_test(
         args = parse_args(flags + ["EMPTY", "EMPTY"])
         out, err = outs()
         assert run(args, out=out, err=err) == 0
+
+
+def test_table_returning_function_change():
+    """Verify functions with changed RETURNS TABLE get DROP + CREATE."""
+    with temporary_database() as d0, temporary_database() as d1:
+        with connect(d0) as s0:
+            s0.execute("""
+                CREATE FUNCTION get_users()
+                RETURNS TABLE(id integer, name text)
+                LANGUAGE sql STABLE AS
+                'SELECT 1, ''test''::text';
+            """)
+        with connect(d1) as s1:
+            s1.execute("""
+                CREATE FUNCTION get_users()
+                RETURNS TABLE(id integer, name text, email text)
+                LANGUAGE sql STABLE AS
+                'SELECT 1, ''test''::text, ''test@test.com''::text';
+            """)
+
+        with connect(d0) as s0, connect(d1) as s1:
+            m = Migration(s0, s1)
+            m.set_safety(False)
+            m.add_all_changes()
+
+            sql_out = m.sql
+            assert "drop function" in sql_out.lower(), (
+                f"DROP FUNCTION not found - TABLE-returning function change not detected.\n{sql_out}"
+            )
+            assert "get_users" in sql_out, (
+                f"get_users not found in migration SQL.\n{sql_out}"
+            )

--- a/packages/migra/tests/test_migra.py
+++ b/packages/migra/tests/test_migra.py
@@ -229,35 +229,3 @@ def do_fixture_test(
         args = parse_args(flags + ["EMPTY", "EMPTY"])
         out, err = outs()
         assert run(args, out=out, err=err) == 0
-
-
-def test_table_returning_function_change():
-    """Verify functions with changed RETURNS TABLE get DROP + CREATE."""
-    with temporary_database() as d0, temporary_database() as d1:
-        with connect(d0) as s0:
-            s0.execute("""
-                CREATE FUNCTION get_users()
-                RETURNS TABLE(id integer, name text)
-                LANGUAGE sql STABLE AS
-                'SELECT 1, ''test''::text';
-            """)
-        with connect(d1) as s1:
-            s1.execute("""
-                CREATE FUNCTION get_users()
-                RETURNS TABLE(id integer, name text, email text)
-                LANGUAGE sql STABLE AS
-                'SELECT 1, ''test''::text, ''test@test.com''::text';
-            """)
-
-        with connect(d0) as s0, connect(d1) as s1:
-            m = Migration(s0, s1)
-            m.set_safety(False)
-            m.add_all_changes()
-
-            sql_out = m.sql
-            assert "drop function" in sql_out.lower(), (
-                f"DROP FUNCTION not found - TABLE-returning function change not detected.\n{sql_out}"
-            )
-            assert "get_users" in sql_out, (
-                f"get_users not found in migration SQL.\n{sql_out}"
-            )

--- a/packages/migra/tests/test_table_functions.py
+++ b/packages/migra/tests/test_table_functions.py
@@ -1,0 +1,34 @@
+from migra import Migration
+from migra.db import connect, temporary_database
+
+
+def test_table_returning_function_change():
+    """Verify functions with changed RETURNS TABLE get DROP + CREATE."""
+    with temporary_database() as d0, temporary_database() as d1:
+        with connect(d0) as s0:
+            s0.execute("""
+                CREATE FUNCTION get_users()
+                RETURNS TABLE(id integer, name text)
+                LANGUAGE sql STABLE AS
+                'SELECT 1, ''test''::text';
+            """)
+        with connect(d1) as s1:
+            s1.execute("""
+                CREATE FUNCTION get_users()
+                RETURNS TABLE(id integer, name text, email text)
+                LANGUAGE sql STABLE AS
+                'SELECT 1, ''test''::text, ''test@test.com''::text';
+            """)
+
+        with connect(d0) as s0, connect(d1) as s1:
+            m = Migration(s0, s1)
+            m.set_safety(False)
+            m.add_all_changes()
+
+            sql_out = m.sql
+            assert "drop function" in sql_out.lower(), (
+                f"DROP FUNCTION not found - TABLE-returning function change not detected.\n{sql_out}"
+            )
+            assert "get_users" in sql_out, (
+                f"get_users not found in migration SQL.\n{sql_out}"
+            )


### PR DESCRIPTION
## Summary
- Overrides `can_replace` in `InspectedFunction` to compare `result_string` before allowing `CREATE OR REPLACE`
- When a function's `RETURNS TABLE(...)` columns change (added, removed, or type changed), migra now correctly emits `DROP` + `CREATE` instead of just `CREATE OR REPLACE`, which would fail in PostgreSQL
- Fixes the root cause: the base `InspectedSelectable.can_replace` didn't account for TABLE return type differences specific to functions

Closes #4

## Test plan
- [ ] Verify with two schemas where a function's `RETURNS TABLE` has different columns — migra should generate a `DROP FUNCTION` followed by `CREATE FUNCTION`
- [ ] Verify that functions with unchanged `RETURNS TABLE` signatures still use `CREATE OR REPLACE`
- [ ] Verify that non-TABLE-returning functions are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)