### PR TITLE
Fix identifier quoting in ALTER TYPE statements

### DIFF
--- a/packages/migra/migra/schemainspect/inspected.py
+++ b/packages/migra/migra/schemainspect/inspected.py
@@ -163,7 +163,7 @@ class ColumnInfo(AutoRepr):
     def change_enum_statement(self, table_name):
         if self.is_enum:
             assert self.enum is not None
-            return f"alter table {table_name} alter column {self.name} type {self.enum.quoted_full_name} using {self.name}::text::{self.enum.quoted_full_name};"
+            return f"alter table {table_name} alter column {self.quoted_name} type {self.enum.quoted_full_name} using {self.quoted_name}::text::{self.enum.quoted_full_name};"
         else:
             raise ValueError
 

--- a/packages/migra/tests/test_migra.py
+++ b/packages/migra/tests/test_migra.py
@@ -229,3 +229,30 @@ def do_fixture_test(
         args = parse_args(flags + ["EMPTY", "EMPTY"])
         out, err = outs()
         assert run(args, out=out, err=err) == 0
+
+
+def test_enum_column_quoting():
+    """Verify mixed-case column names are properly quoted in enum ALTER statements."""
+    with temporary_database() as d0, temporary_database() as d1:
+        for url in [d0, d1]:
+            with connect(url) as s:
+                s.execute("CREATE TYPE status_type AS ENUM ('active');")
+
+        with connect(d0) as s0:
+            s0.execute('CREATE TABLE items ("StatusCode" status_type);')
+        with connect(d1) as s1:
+            s1.execute("DROP TYPE status_type;")
+            s1.execute("CREATE TYPE status_type AS ENUM ('active', 'inactive');")
+            s1.execute('CREATE TABLE items ("StatusCode" status_type);')
+
+        with connect(d0) as s0, connect(d1) as s1:
+            m = Migration(s0, s1)
+            m.set_safety(False)
+            m.add_all_changes()
+
+            sql_out = m.sql
+            if sql_out:
+                if "StatusCode" in sql_out or "statuscode" in sql_out:
+                    assert '"StatusCode"' in sql_out, (
+                        f"Mixed-case column name not properly quoted in SQL:\n{sql_out}"
+                    )

--- a/packages/migra/tests/test_migra.py
+++ b/packages/migra/tests/test_migra.py
@@ -229,30 +229,3 @@ def do_fixture_test(
         args = parse_args(flags + ["EMPTY", "EMPTY"])
         out, err = outs()
         assert run(args, out=out, err=err) == 0
-
-
-def test_enum_column_quoting():
-    """Verify mixed-case column names are properly quoted in enum ALTER statements."""
-    with temporary_database() as d0, temporary_database() as d1:
-        for url in [d0, d1]:
-            with connect(url) as s:
-                s.execute("CREATE TYPE status_type AS ENUM ('active');")
-
-        with connect(d0) as s0:
-            s0.execute('CREATE TABLE items ("StatusCode" status_type);')
-        with connect(d1) as s1:
-            s1.execute("DROP TYPE status_type;")
-            s1.execute("CREATE TYPE status_type AS ENUM ('active', 'inactive');")
-            s1.execute('CREATE TABLE items ("StatusCode" status_type);')
-
-        with connect(d0) as s0, connect(d1) as s1:
-            m = Migration(s0, s1)
-            m.set_safety(False)
-            m.add_all_changes()
-
-            sql_out = m.sql
-            if sql_out:
-                if "StatusCode" in sql_out or "statuscode" in sql_out:
-                    assert '"StatusCode"' in sql_out, (
-                        f"Mixed-case column name not properly quoted in SQL:\n{sql_out}"
-                    )

--- a/packages/migra/tests/test_quoting.py
+++ b/packages/migra/tests/test_quoting.py
@@ -1,0 +1,29 @@
+from migra import Migration
+from migra.db import connect, temporary_database
+
+
+def test_enum_column_quoting():
+    """Verify mixed-case column names are properly quoted in enum ALTER statements."""
+    with temporary_database() as d0, temporary_database() as d1:
+        for url in [d0, d1]:
+            with connect(url) as s:
+                s.execute("CREATE TYPE status_type AS ENUM ('active');")
+
+        with connect(d0) as s0:
+            s0.execute('CREATE TABLE items ("StatusCode" status_type);')
+        with connect(d1) as s1:
+            s1.execute("DROP TYPE status_type;")
+            s1.execute("CREATE TYPE status_type AS ENUM ('active', 'inactive');")
+            s1.execute('CREATE TABLE items ("StatusCode" status_type);')
+
+        with connect(d0) as s0, connect(d1) as s1:
+            m = Migration(s0, s1)
+            m.set_safety(False)
+            m.add_all_changes()
+
+            sql_out = m.sql
+            if sql_out:
+                if "StatusCode" in sql_out or "statuscode" in sql_out:
+                    assert '"StatusCode"' in sql_out, (
+                        f"Mixed-case column name not properly quoted in SQL:\n{sql_out}"
+                    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "psycopg[binary]",
+    "pyyaml",
     "ruff",
     "ty",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -182,6 +182,7 @@ dev = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -194,6 +195,7 @@ dev = [
     { name = "psycopg", extras = ["binary"] },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pyyaml" },
     { name = "ruff" },
     { name = "ty" },
 ]


### PR DESCRIPTION
## Summary

- Fix `ColumnInfo.change_enum_statement` to use `self.quoted_name` instead of `self.name`, producing correctly quoted SQL for case-sensitive column identifiers in ALTER TYPE statements.

Closes #3

## Test plan

- [ ] Verify that `change_enum_statement` generates valid SQL for columns with case-sensitive names (e.g., `"MyColumn"`)
- [ ] Confirm that existing enum migration behavior is unchanged for lowercase column names

Generated with [Claude Code](https://claude.com/claude-code)