### PR TITLE
Support password-less and PGPASSWORD connections

### DIFF
--- a/packages/migra/migra/db.py
+++ b/packages/migra/migra/db.py
@@ -11,8 +11,13 @@ from psycopg import sql
 from psycopg.rows import namedtuple_row
 
 
-def _pg_url(host: str, port: str, user: str, dbname: str) -> str:
-    userspec = f"{user}@" if user else ""
+def _pg_url(host: str, port: str, user: str, dbname: str, password: str = "") -> str:
+    userspec = ""
+    if user:
+        if password:
+            userspec = f"{user}:{password}@"
+        else:
+            userspec = f"{user}@"
     return f"postgresql://{userspec}{host}:{port}/{dbname}"
 
 
@@ -36,11 +41,12 @@ def temporary_database(host: str = "localhost") -> Generator[str, None, None]:
     host = os.environ.get("PGHOST", host)
     port = os.environ.get("PGPORT", "5432")
     user = os.environ.get("PGUSER", "")
+    password = os.environ.get("PGPASSWORD", "")
     dbname = f"test_{uuid4().hex[:12]}"
-    admin_url = _pg_url(host, port, user, "postgres")
+    admin_url = _pg_url(host, port, user, "postgres", password)
     with psycopg.connect(admin_url, autocommit=True) as admin_conn:
         admin_conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(dbname)))
-    url = _pg_url(host, port, user, dbname)
+    url = _pg_url(host, port, user, dbname, password)
     try:
         yield url
     finally:

--- a/packages/migra/tests/test_connections.py
+++ b/packages/migra/tests/test_connections.py
@@ -1,0 +1,25 @@
+from migra.db import _pg_url, connect, temporary_database
+
+
+def test_pg_url_formats():
+    """Verify _pg_url handles various auth configurations."""
+    url = _pg_url("localhost", "5432", "", "testdb")
+    assert url == "postgresql://localhost:5432/testdb"
+
+    url = _pg_url("localhost", "5432", "myuser", "testdb")
+    assert url == "postgresql://myuser@localhost:5432/testdb"
+
+    url = _pg_url("localhost", "5432", "myuser", "testdb", "secret")
+    assert url == "postgresql://myuser:secret@localhost:5432/testdb"
+
+    url = _pg_url("localhost", "5432", "myuser", "testdb", "")
+    assert url == "postgresql://myuser@localhost:5432/testdb"
+
+
+def test_temporary_database_works():
+    """Verify temporary_database creates and cleans up databases."""
+    with temporary_database() as url:
+        assert "postgresql://" in url
+        with connect(url) as conn:
+            result = conn.execute("SELECT 1 as x")
+            assert list(result)[0].x == 1

--- a/packages/migra/tests/test_migra.py
+++ b/packages/migra/tests/test_migra.py
@@ -229,36 +229,3 @@ def do_fixture_test(
         args = parse_args(flags + ["EMPTY", "EMPTY"])
         out, err = outs()
         assert run(args, out=out, err=err) == 0
-
-
-def test_pg_url_formats():
-    """Verify _pg_url handles various auth configurations."""
-    from migra.db import _pg_url
-
-    # No user, no password
-    url = _pg_url("localhost", "5432", "", "testdb")
-    assert url == "postgresql://localhost:5432/testdb"
-
-    # User without password (trust auth / .pgpass)
-    url = _pg_url("localhost", "5432", "myuser", "testdb")
-    assert url == "postgresql://myuser@localhost:5432/testdb"
-
-    # User with password
-    url = _pg_url("localhost", "5432", "myuser", "testdb", "secret")
-    assert url == "postgresql://myuser:secret@localhost:5432/testdb"
-
-    # Empty password string (same as no password)
-    url = _pg_url("localhost", "5432", "myuser", "testdb", "")
-    assert url == "postgresql://myuser@localhost:5432/testdb"
-
-
-def test_temporary_database_works():
-    """Verify temporary_database creates and cleans up databases."""
-    from migra.db import temporary_database, connect
-
-    with temporary_database() as url:
-        assert "postgresql://" in url
-        # Should be able to connect
-        with connect(url) as conn:
-            result = conn.execute("SELECT 1 as x")
-            assert list(result)[0].x == 1

--- a/packages/migra/tests/test_migra.py
+++ b/packages/migra/tests/test_migra.py
@@ -229,3 +229,36 @@ def do_fixture_test(
         args = parse_args(flags + ["EMPTY", "EMPTY"])
         out, err = outs()
         assert run(args, out=out, err=err) == 0
+
+
+def test_pg_url_formats():
+    """Verify _pg_url handles various auth configurations."""
+    from migra.db import _pg_url
+
+    # No user, no password
+    url = _pg_url("localhost", "5432", "", "testdb")
+    assert url == "postgresql://localhost:5432/testdb"
+
+    # User without password (trust auth / .pgpass)
+    url = _pg_url("localhost", "5432", "myuser", "testdb")
+    assert url == "postgresql://myuser@localhost:5432/testdb"
+
+    # User with password
+    url = _pg_url("localhost", "5432", "myuser", "testdb", "secret")
+    assert url == "postgresql://myuser:secret@localhost:5432/testdb"
+
+    # Empty password string (same as no password)
+    url = _pg_url("localhost", "5432", "myuser", "testdb", "")
+    assert url == "postgresql://myuser@localhost:5432/testdb"
+
+
+def test_temporary_database_works():
+    """Verify temporary_database creates and cleans up databases."""
+    from migra.db import temporary_database, connect
+
+    with temporary_database() as url:
+        assert "postgresql://" in url
+        # Should be able to connect
+        with connect(url) as conn:
+            result = conn.execute("SELECT 1 as x")
+            assert list(result)[0].x == 1


### PR DESCRIPTION
## Summary
- Update `_pg_url` helper to accept an optional `password` parameter, constructing the URI with credentials when provided and omitting them for password-less (`.pgpass`/trust auth) connections
- Add `PGPASSWORD` environment variable support in `temporary_database` so test databases can authenticate via environment in addition to `.pgpass`
- The main `connect()` path already works with `.pgpass` natively via psycopg/libpq -- no changes needed there

Closes #10

## Test plan
- [ ] Verify existing tests still pass with default (no password) configuration
- [ ] Test with `PGPASSWORD` env var set to confirm password is included in generated URIs
- [ ] Test with `.pgpass` file configured (no `PGPASSWORD`) to confirm password-less URIs work via libpq lookup
- [ ] Test with trust auth to confirm connections without any credentials succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)